### PR TITLE
API: make name of metric spec optional

### DIFF
--- a/apis/autoscaling/v1alpha1/horizontalportrait_types.go
+++ b/apis/autoscaling/v1alpha1/horizontalportrait_types.go
@@ -74,9 +74,12 @@ const (
 // MetricSpec represents the configuration for a single metric.
 // It is an extended autoscalingv2.MetricSpec.
 type MetricSpec struct {
-	// Name is the name of this metric.
-	// It must be unique across all metrics.
-	Name string `json:"name"`
+	k8sautoscalingv2.MetricSpec `json:",inline"`
+
+	// Name is the unique identifier of this metric spec.
+	// It must be unique across all metric specs if specified.
+	// +optional
+	Name string `json:"name,omitempty"`
 
 	// Operator is an optional binary arithmetic operator which is used to specify
 	// a custom comparison rule "<actual> <operator> <target>" for the metric.
@@ -84,8 +87,6 @@ type MetricSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum===;>;<;>=;<=
 	Operator Operator `json:"operator,omitempty"`
-
-	k8sautoscalingv2.MetricSpec `json:",inline"`
 }
 
 type Operator string

--- a/config/crd/bases/autoscaling.kapacity.traas.io_horizontalportraits.yaml
+++ b/config/crd/bases/autoscaling.kapacity.traas.io_horizontalportraits.yaml
@@ -258,8 +258,8 @@ spec:
                       - target
                       type: object
                     name:
-                      description: Name is the name of this metric. It must be unique
-                        across all metrics.
+                      description: Name is the unique identifier of this metric spec.
+                        It must be unique across all metric specs if specified.
                       type: string
                     object:
                       description: object refers to a metric describing a single kubernetes
@@ -564,7 +564,6 @@ spec:
                         HPAContainerMetrics is enabled'
                       type: string
                   required:
-                  - name
                   - type
                   type: object
                 type: array

--- a/config/crd/bases/autoscaling.kapacity.traas.io_intelligenthorizontalpodautoscalers.yaml
+++ b/config/crd/bases/autoscaling.kapacity.traas.io_intelligenthorizontalpodautoscalers.yaml
@@ -531,8 +531,9 @@ spec:
                                 - target
                                 type: object
                               name:
-                                description: Name is the name of this metric. It must
-                                  be unique across all metrics.
+                                description: Name is the unique identifier of this
+                                  metric spec. It must be unique across all metric
+                                  specs if specified.
                                 type: string
                               object:
                                 description: object refers to a metric describing
@@ -860,7 +861,6 @@ spec:
                                   is enabled'
                                 type: string
                             required:
-                            - name
                             - type
                             type: object
                           type: array
@@ -1151,8 +1151,9 @@ spec:
                                 - target
                                 type: object
                               name:
-                                description: Name is the name of this metric. It must
-                                  be unique across all metrics.
+                                description: Name is the unique identifier of this
+                                  metric spec. It must be unique across all metric
+                                  specs if specified.
                                 type: string
                               object:
                                 description: object refers to a metric describing
@@ -1480,7 +1481,6 @@ spec:
                                   is enabled'
                                 type: string
                             required:
-                            - name
                             - type
                             type: object
                           minItems: 1

--- a/pkg/portrait/generator/reactive/generator.go
+++ b/pkg/portrait/generator/reactive/generator.go
@@ -107,11 +107,11 @@ func (g *PortraitGenerator) GenerateHorizontal(ctx context.Context, namespace st
 	for _, metric := range metrics {
 		replicasProposal, err := replicaCalc.ComputeReplicasForMetric(ctx, specReplicas, metric, namespace, selector)
 		if err != nil {
+			l.Error(err, "failed to compute replicas for metric")
 			if invalidMetricsCount == 0 {
 				invalidMetricError = err
 			}
 			invalidMetricsCount++
-			l.Error(err, "failed to compute replicas for metric", "metricName", metric.Name)
 			continue
 		}
 		if replicasProposal > replicas {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
This PR makes the `name` field of `MetricSpec` be optional because it is meaningless in some cases.
