### PR TITLE
ReplicaProfile: support deployment and replicaset pod sorting

### DIFF
--- a/pkg/pod/sorter/active_pods_with_ranks.go
+++ b/pkg/pod/sorter/active_pods_with_ranks.go
@@ -1,0 +1,271 @@
+/*
+ Copyright 2023 The Kapacity Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/*
+ This file contains code derived from and/or modified from Kubernetes
+ which is licensed under below license:
+
+ Copyright 2014 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package sorter
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/integer"
+
+	"github.com/traas-stack/kapacity/pkg/util"
+)
+
+var (
+	podPhaseToOrdinal = map[corev1.PodPhase]int{corev1.PodPending: 0, corev1.PodUnknown: 1, corev1.PodRunning: 2}
+
+	// TODO(zqzten): make below configurable
+	podDeletionCostEnabled      = true
+	logarithmicScaleDownEnabled = true
+)
+
+// ActivePodsWithRanks sorts pods with a list of corresponding ranks which will be considered during sorting.
+// The list's length must be equal to the length of pod list to be sorted.
+// After sorting, the pods will be ordered as follows, applying each
+// rule in turn until one matches:
+//
+//  1. If only one of the pods is assigned to a node, the pod that is not
+//     assigned comes before the pod that is.
+//  2. If the pods' phases differ, a pending pod comes before a pod whose phase
+//     is unknown, and a pod whose phase is unknown comes before a running pod.
+//  3. If exactly one of the pods is ready, the pod that is not ready comes
+//     before the ready pod.
+//  4. If controller.kubernetes.io/pod-deletion-cost annotation is set, then
+//     the pod with the lower value will come first.
+//  5. If the pods' ranks differ, the pod with greater rank comes before the pod
+//     with lower rank.
+//  6. If both pods are ready but have not been ready for the same amount of
+//     time, the pod that has been ready for a shorter amount of time comes
+//     before the pod that has been ready for longer.
+//  7. If one pod has a container that has restarted more than any container in
+//     the other pod, the pod with the container with more restarts comes
+//     before the other pod.
+//  8. If the pods' creation times differ, the pod that was created more recently
+//     comes before the older pod.
+//
+// In 6 and 8, times are compared in a logarithmic scale. This allows a level
+// of randomness among equivalent Pods when sorting. If two pods have the same
+// logarithmic rank, they are sorted by UUID to provide a pseudorandom order.
+//
+// If none of these rules matches, the second pod comes before the first pod.
+//
+// This ordering is the same with the one used by Kubernetes ReplicaSet to choose pods
+// that should be preferred for deletion first.
+type ActivePodsWithRanks struct {
+	// Rank is a ranking of pods.
+	// This ranking is used during sorting when comparing two pods that are both scheduled,
+	// in the same phase, and having the same ready status.
+	Ranks []int
+
+	// Now is a reference timestamp for doing logarithmic timestamp comparisons.
+	// If zero, comparison happens without scaling.
+	Now metav1.Time
+}
+
+func (s *ActivePodsWithRanks) Sort(_ context.Context, pods []*corev1.Pod) ([]*corev1.Pod, error) {
+	sort.Sort(activePodsWithRanks{
+		Pods:  pods,
+		Ranks: s.Ranks,
+		Now:   s.Now,
+	})
+	return pods, nil
+}
+
+type activePodsWithRanks struct {
+	Pods  []*corev1.Pod
+	Ranks []int
+	Now   metav1.Time
+}
+
+func (s activePodsWithRanks) Len() int {
+	return len(s.Pods)
+}
+
+func (s activePodsWithRanks) Swap(i, j int) {
+	s.Pods[i], s.Pods[j] = s.Pods[j], s.Pods[i]
+	s.Ranks[i], s.Ranks[j] = s.Ranks[j], s.Ranks[i]
+}
+
+func (s activePodsWithRanks) Less(i, j int) bool {
+	// 1. Unassigned < assigned
+	// If only one of the pods is unassigned, the unassigned one is smaller
+	if s.Pods[i].Spec.NodeName != s.Pods[j].Spec.NodeName && (len(s.Pods[i].Spec.NodeName) == 0 || len(s.Pods[j].Spec.NodeName) == 0) {
+		return len(s.Pods[i].Spec.NodeName) == 0
+	}
+	// 2. PodPending < PodUnknown < PodRunning
+	if podPhaseToOrdinal[s.Pods[i].Status.Phase] != podPhaseToOrdinal[s.Pods[j].Status.Phase] {
+		return podPhaseToOrdinal[s.Pods[i].Status.Phase] < podPhaseToOrdinal[s.Pods[j].Status.Phase]
+	}
+	// 3. Not ready < ready
+	// If only one of the pods is not ready, the not ready one is smaller
+	if util.IsPodReady(s.Pods[i]) != util.IsPodReady(s.Pods[j]) {
+		return !util.IsPodReady(s.Pods[i])
+	}
+
+	// 4. lower pod-deletion-cost < higher pod-deletion cost
+	if podDeletionCostEnabled {
+		pi, _ := getDeletionCostFromPodAnnotations(s.Pods[i].Annotations)
+		pj, _ := getDeletionCostFromPodAnnotations(s.Pods[j].Annotations)
+		if pi != pj {
+			return pi < pj
+		}
+	}
+
+	// 5. Doubled up < not doubled up
+	// If one of the two pods is on the same node as one or more additional
+	// ready pods that belong to the same replicaset, whichever pod has more
+	// colocated ready pods is less
+	if s.Ranks[i] != s.Ranks[j] {
+		return s.Ranks[i] > s.Ranks[j]
+	}
+
+	// 6. Been ready for empty time < less time < more time
+	// If both pods are ready, the latest ready one is smaller
+	if util.IsPodReady(s.Pods[i]) && util.IsPodReady(s.Pods[j]) {
+		readyTime1 := podReadyTime(s.Pods[i])
+		readyTime2 := podReadyTime(s.Pods[j])
+		if !readyTime1.Equal(readyTime2) {
+			if !logarithmicScaleDownEnabled {
+				return afterOrZero(readyTime1, readyTime2)
+			} else {
+				if s.Now.IsZero() || readyTime1.IsZero() || readyTime2.IsZero() {
+					return afterOrZero(readyTime1, readyTime2)
+				}
+				rankDiff := logarithmicRankDiff(*readyTime1, *readyTime2, s.Now)
+				if rankDiff == 0 {
+					return s.Pods[i].UID < s.Pods[j].UID
+				}
+				return rankDiff < 0
+			}
+		}
+	}
+	// 7. Pods with containers with higher restart counts < lower restart counts
+	if maxContainerRestarts(s.Pods[i]) != maxContainerRestarts(s.Pods[j]) {
+		return maxContainerRestarts(s.Pods[i]) > maxContainerRestarts(s.Pods[j])
+	}
+	// 8. Empty creation time pods < newer pods < older pods
+	if !s.Pods[i].CreationTimestamp.Equal(&s.Pods[j].CreationTimestamp) {
+		if !logarithmicScaleDownEnabled {
+			return afterOrZero(&s.Pods[i].CreationTimestamp, &s.Pods[j].CreationTimestamp)
+		} else {
+			if s.Now.IsZero() || s.Pods[i].CreationTimestamp.IsZero() || s.Pods[j].CreationTimestamp.IsZero() {
+				return afterOrZero(&s.Pods[i].CreationTimestamp, &s.Pods[j].CreationTimestamp)
+			}
+			rankDiff := logarithmicRankDiff(s.Pods[i].CreationTimestamp, s.Pods[j].CreationTimestamp, s.Now)
+			if rankDiff == 0 {
+				return s.Pods[i].UID < s.Pods[j].UID
+			}
+			return rankDiff < 0
+		}
+	}
+	return false
+}
+
+// afterOrZero checks if time t1 is after time t2; if one of them is zero,
+// the zero time is seen as after non-zero time.
+func afterOrZero(t1, t2 *metav1.Time) bool {
+	if t1.Time.IsZero() || t2.Time.IsZero() {
+		return t1.Time.IsZero()
+	}
+	return t1.After(t2.Time)
+}
+
+// logarithmicRankDiff calculates the base-2 logarithmic ranks of 2 timestamps,
+// compared to the current timestamp.
+func logarithmicRankDiff(t1, t2, now metav1.Time) int64 {
+	d1 := now.Sub(t1.Time)
+	d2 := now.Sub(t2.Time)
+	r1 := int64(-1)
+	r2 := int64(-1)
+	if d1 > 0 {
+		r1 = int64(math.Log2(float64(d1)))
+	}
+	if d2 > 0 {
+		r2 = int64(math.Log2(float64(d2)))
+	}
+	return r1 - r2
+}
+
+func podReadyTime(pod *corev1.Pod) *metav1.Time {
+	if util.IsPodReady(pod) {
+		for _, c := range pod.Status.Conditions {
+			// we only care about pod ready conditions
+			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+				return &c.LastTransitionTime
+			}
+		}
+	}
+	return &metav1.Time{}
+}
+
+func maxContainerRestarts(pod *corev1.Pod) int {
+	maxRestarts := 0
+	for _, c := range pod.Status.ContainerStatuses {
+		maxRestarts = integer.IntMax(maxRestarts, int(c.RestartCount))
+	}
+	return maxRestarts
+}
+
+// getDeletionCostFromPodAnnotations returns the integer value of pod-deletion-cost.
+// Returns 0 if not set or the value is invalid.
+func getDeletionCostFromPodAnnotations(annotations map[string]string) (int32, error) {
+	if value, exist := annotations[corev1.PodDeletionCost]; exist {
+		// values that start with plus sign (e.g, "+10") or leading zeros (e.g., "008") are not valid.
+		if !validFirstDigit(value) {
+			return 0, fmt.Errorf("invalid value %q", value)
+		}
+
+		i, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			// make sure we default to 0 on error.
+			return 0, err
+		}
+		return int32(i), nil
+	}
+	return 0, nil
+}
+
+func validFirstDigit(str string) bool {
+	if len(str) == 0 {
+		return false
+	}
+	return str[0] == '-' || (str[0] == '0' && str == "0") || (str[0] >= '1' && str[0] <= '9')
+}

--- a/pkg/pod/sorter/active_pods_with_ranks_test.go
+++ b/pkg/pod/sorter/active_pods_with_ranks_test.go
@@ -1,0 +1,168 @@
+/*
+ Copyright 2023 The Kapacity Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/*
+ This file contains code derived from and/or modified from Kubernetes
+ which is licensed under below license:
+
+ Copyright 2015 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package sorter
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestActivePodsWithRanks_Sort(t *testing.T) {
+	now := metav1.Now()
+	then1Month := metav1.Time{Time: now.AddDate(0, -1, 0)}
+	then2Hours := metav1.Time{Time: now.Add(-2 * time.Hour)}
+	then5Hours := metav1.Time{Time: now.Add(-5 * time.Hour)}
+	then8Hours := metav1.Time{Time: now.Add(-8 * time.Hour)}
+	zeroTime := metav1.Time{}
+	pod := func(podName, nodeName string, phase corev1.PodPhase, ready bool, restarts int32, readySince metav1.Time, created metav1.Time, annotations map[string]string) *corev1.Pod {
+		var conditions []corev1.PodCondition
+		var containerStatuses []corev1.ContainerStatus
+		if ready {
+			conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: readySince}}
+			containerStatuses = []corev1.ContainerStatus{{RestartCount: restarts}}
+		}
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: created,
+				Name:              podName,
+				Annotations:       annotations,
+			},
+			Spec: corev1.PodSpec{NodeName: nodeName},
+			Status: corev1.PodStatus{
+				Conditions:        conditions,
+				ContainerStatuses: containerStatuses,
+				Phase:             phase,
+			},
+		}
+	}
+	var (
+		unscheduledPod                      = pod("unscheduled", "", corev1.PodPending, false, 0, zeroTime, zeroTime, nil)
+		scheduledPendingPod                 = pod("pending", "node", corev1.PodPending, false, 0, zeroTime, zeroTime, nil)
+		unknownPhasePod                     = pod("unknown-phase", "node", corev1.PodUnknown, false, 0, zeroTime, zeroTime, nil)
+		runningNotReadyPod                  = pod("not-ready", "node", corev1.PodRunning, false, 0, zeroTime, zeroTime, nil)
+		runningReadyNoLastTransitionTimePod = pod("ready-no-last-transition-time", "node", corev1.PodRunning, true, 0, zeroTime, zeroTime, nil)
+		runningReadyNow                     = pod("ready-now", "node", corev1.PodRunning, true, 0, now, now, nil)
+		runningReadyThen                    = pod("ready-then", "node", corev1.PodRunning, true, 0, then1Month, then1Month, nil)
+		runningReadyNowHighRestarts         = pod("ready-high-restarts", "node", corev1.PodRunning, true, 9001, now, now, nil)
+		runningReadyNowCreatedThen          = pod("ready-now-created-then", "node", corev1.PodRunning, true, 0, now, then1Month, nil)
+		lowPodDeletionCost                  = pod("low-deletion-cost", "node", corev1.PodRunning, true, 0, now, then1Month, map[string]string{corev1.PodDeletionCost: "10"})
+		highPodDeletionCost                 = pod("high-deletion-cost", "node", corev1.PodRunning, true, 0, now, then1Month, map[string]string{corev1.PodDeletionCost: "100"})
+		unscheduled5Hours                   = pod("unscheduled-5-hours", "", corev1.PodPending, false, 0, then5Hours, then5Hours, nil)
+		unscheduled8Hours                   = pod("unscheduled-10-hours", "", corev1.PodPending, false, 0, then8Hours, then8Hours, nil)
+		ready2Hours                         = pod("ready-2-hours", "", corev1.PodRunning, true, 0, then2Hours, then1Month, nil)
+		ready5Hours                         = pod("ready-5-hours", "", corev1.PodRunning, true, 0, then5Hours, then1Month, nil)
+		ready10Hours                        = pod("ready-10-hours", "", corev1.PodRunning, true, 0, then8Hours, then1Month, nil)
+	)
+	equalityTests := []struct {
+		p1                          *corev1.Pod
+		p2                          *corev1.Pod
+		disableLogarithmicScaleDown bool
+	}{
+		{p1: unscheduledPod},
+		{p1: scheduledPendingPod},
+		{p1: unknownPhasePod},
+		{p1: runningNotReadyPod},
+		{p1: runningReadyNowCreatedThen},
+		{p1: runningReadyNow},
+		{p1: runningReadyThen},
+		{p1: runningReadyNowHighRestarts},
+		{p1: runningReadyNowCreatedThen},
+		{p1: unscheduled5Hours, p2: unscheduled8Hours},
+		{p1: ready5Hours, p2: ready10Hours},
+	}
+	for _, tc := range equalityTests {
+		logarithmicScaleDownEnabled = !tc.disableLogarithmicScaleDown
+		if tc.p2 == nil {
+			tc.p2 = tc.p1
+		}
+		podsWithRanks := activePodsWithRanks{
+			Pods:  []*corev1.Pod{tc.p1, tc.p2},
+			Ranks: []int{1, 1},
+			Now:   now,
+		}
+		if podsWithRanks.Less(0, 1) || podsWithRanks.Less(1, 0) {
+			t.Errorf("expected pod %q to be equivalent to %q", tc.p1.Name, tc.p2.Name)
+		}
+	}
+	type podWithRank struct {
+		pod  *corev1.Pod
+		rank int
+	}
+	inequalityTests := []struct {
+		lesser, greater             podWithRank
+		disablePodDeletioncost      bool
+		disableLogarithmicScaleDown bool
+	}{
+		{lesser: podWithRank{unscheduledPod, 1}, greater: podWithRank{scheduledPendingPod, 2}},
+		{lesser: podWithRank{unscheduledPod, 2}, greater: podWithRank{scheduledPendingPod, 1}},
+		{lesser: podWithRank{scheduledPendingPod, 1}, greater: podWithRank{unknownPhasePod, 2}},
+		{lesser: podWithRank{unknownPhasePod, 1}, greater: podWithRank{runningNotReadyPod, 2}},
+		{lesser: podWithRank{runningNotReadyPod, 1}, greater: podWithRank{runningReadyNoLastTransitionTimePod, 1}},
+		{lesser: podWithRank{runningReadyNoLastTransitionTimePod, 1}, greater: podWithRank{runningReadyNow, 1}},
+		{lesser: podWithRank{runningReadyNow, 2}, greater: podWithRank{runningReadyNoLastTransitionTimePod, 1}},
+		{lesser: podWithRank{runningReadyNow, 1}, greater: podWithRank{runningReadyThen, 1}},
+		{lesser: podWithRank{runningReadyNow, 2}, greater: podWithRank{runningReadyThen, 1}},
+		{lesser: podWithRank{runningReadyNowHighRestarts, 1}, greater: podWithRank{runningReadyNow, 1}},
+		{lesser: podWithRank{runningReadyNow, 2}, greater: podWithRank{runningReadyNowHighRestarts, 1}},
+		{lesser: podWithRank{runningReadyNow, 1}, greater: podWithRank{runningReadyNowCreatedThen, 1}},
+		{lesser: podWithRank{runningReadyNowCreatedThen, 2}, greater: podWithRank{runningReadyNow, 1}},
+		{lesser: podWithRank{lowPodDeletionCost, 2}, greater: podWithRank{highPodDeletionCost, 1}},
+		{lesser: podWithRank{highPodDeletionCost, 2}, greater: podWithRank{lowPodDeletionCost, 1}, disablePodDeletioncost: true},
+		{lesser: podWithRank{ready2Hours, 1}, greater: podWithRank{ready5Hours, 1}},
+	}
+	for i, test := range inequalityTests {
+		t.Run(fmt.Sprintf("test%d", i), func(t *testing.T) {
+			podDeletionCostEnabled = !test.disablePodDeletioncost
+			logarithmicScaleDownEnabled = !test.disableLogarithmicScaleDown
+
+			podsWithRanks := activePodsWithRanks{
+				Pods:  []*corev1.Pod{test.lesser.pod, test.greater.pod},
+				Ranks: []int{test.lesser.rank, test.greater.rank},
+				Now:   now,
+			}
+			if !podsWithRanks.Less(0, 1) {
+				t.Errorf("expected pod %q with rank %v to be less than %q with rank %v", podsWithRanks.Pods[0].Name, podsWithRanks.Ranks[0], podsWithRanks.Pods[1].Name, podsWithRanks.Ranks[1])
+			}
+			if podsWithRanks.Less(1, 0) {
+				t.Errorf("expected pod %q with rank %v not to be less than %v with rank %v", podsWithRanks.Pods[1].Name, podsWithRanks.Ranks[1], podsWithRanks.Pods[0].Name, podsWithRanks.Ranks[0])
+			}
+		})
+	}
+}

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -54,6 +54,31 @@ func IsPodRunning(pod *corev1.Pod) bool {
 	return pod.DeletionTimestamp.IsZero() && pod.Status.Phase == corev1.PodRunning
 }
 
+// IsPodActive returns if the given pod has not terminated.
+func IsPodActive(pod *corev1.Pod) bool {
+	return pod.Status.Phase != corev1.PodSucceeded &&
+		pod.Status.Phase != corev1.PodFailed &&
+		pod.DeletionTimestamp.IsZero()
+}
+
+// IsPodReady returns true if a pod is ready; false otherwise.
+func IsPodReady(pod *corev1.Pod) bool {
+	return IsPodReadyConditionTrue(pod.Status)
+}
+
+// IsPodReadyConditionTrue returns true if a pod is ready; false otherwise.
+func IsPodReadyConditionTrue(status corev1.PodStatus) bool {
+	condition := GetPodReadyCondition(status)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
+// GetPodReadyCondition extracts the pod ready condition from the given status and returns that.
+// Returns nil if the condition is not present.
+func GetPodReadyCondition(status corev1.PodStatus) *corev1.PodCondition {
+	_, condition := GetPodCondition(&status, corev1.PodReady)
+	return condition
+}
+
 // GetPodCondition extracts the provided condition from the given status and returns that.
 // Returns nil and -1 if the condition is not present, and the index of the located condition.
 func GetPodCondition(status *corev1.PodStatus, conditionType corev1.PodConditionType) (int, *corev1.PodCondition) {

--- a/pkg/util/pod_test.go
+++ b/pkg/util/pod_test.go
@@ -70,6 +70,57 @@ func TestIsPodRunning(t *testing.T) {
 	assert.False(t, isRunning)
 }
 
+func TestIsPodActive(t *testing.T) {
+	// running pod
+	runningPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-1",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+	assert.True(t, IsPodActive(runningPod))
+
+	// failed pod
+	failedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-2",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+		},
+	}
+	assert.False(t, IsPodActive(failedPod))
+}
+
+func TestIsPodReady(t *testing.T) {
+	// ready pod
+	runningPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-1",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+					Reason: "PodReady",
+				},
+			},
+		},
+	}
+	assert.True(t, IsPodReady(runningPod))
+
+	// not ready pod
+	failedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-2",
+		},
+	}
+	assert.False(t, IsPodReady(failedPod))
+}
+
 func TestGetPodCondition(t *testing.T) {
 	conditions := []corev1.PodCondition{
 		{

--- a/pkg/workload/deployment.go
+++ b/pkg/workload/deployment.go
@@ -21,14 +21,24 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Deployment represents behaviors of a Kubernetes Deployment.
-type Deployment struct{}
+type Deployment struct {
+	client.Client
+	Namespace string
+	Selector  labels.Selector
+}
 
-func (*Deployment) Sort(_ context.Context, pods []*corev1.Pod) ([]*corev1.Pod, error) {
-	// FIXME(zqzten): impl it
-	return pods, nil
+func (w *Deployment) Sort(ctx context.Context, pods []*corev1.Pod) ([]*corev1.Pod, error) {
+	rs := &ReplicaSet{
+		Client:    w.Client,
+		Namespace: w.Namespace,
+		Selector:  w.Selector,
+	}
+	return rs.Sort(ctx, pods)
 }
 
 func (*Deployment) CanSelectPodsToScaleDown(context.Context) bool {

--- a/pkg/workload/replicaset.go
+++ b/pkg/workload/replicaset.go
@@ -1,0 +1,89 @@
+/*
+ Copyright 2023 The Kapacity Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/*
+ This file contains code derived from and/or modified from Kubernetes
+ which is licensed under below license:
+
+ Copyright 2016 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package workload
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	podsorter "github.com/traas-stack/kapacity/pkg/pod/sorter"
+	"github.com/traas-stack/kapacity/pkg/util"
+)
+
+// ReplicaSet represents behaviors of a Kubernetes ReplicaSet.
+type ReplicaSet struct {
+	client.Client
+	Namespace string
+	Selector  labels.Selector
+}
+
+func (w *ReplicaSet) Sort(ctx context.Context, pods []*corev1.Pod) ([]*corev1.Pod, error) {
+	// related pods are all pods which selected by the ReplicaSet
+	relatedPods := &corev1.PodList{}
+	if err := w.List(ctx, relatedPods, client.InNamespace(w.Namespace), client.MatchingLabelsSelector{Selector: w.Selector}); err != nil {
+		return nil, fmt.Errorf("failed to list related pods: %v", err)
+	}
+	// build rank equal to the number of active pods in related pods that are colocated on the same node with the pod
+	podsOnNode := make(map[string]int)
+	for i := range relatedPods.Items {
+		pod := &relatedPods.Items[i]
+		if util.IsPodActive(pod) {
+			podsOnNode[pod.Spec.NodeName]++
+		}
+	}
+	ranks := make([]int, 0, len(pods))
+	for i, pod := range pods {
+		ranks[i] = podsOnNode[pod.Spec.NodeName]
+	}
+	sorter := &podsorter.ActivePodsWithRanks{
+		Ranks: ranks,
+		Now:   metav1.Now(),
+	}
+	return sorter.Sort(ctx, pods)
+}
+
+func (*ReplicaSet) CanSelectPodsToScaleDown(context.Context) bool {
+	return false
+}
+
+func (*ReplicaSet) SelectPodsToScaleDown(context.Context, []*corev1.Pod) error {
+	return fmt.Errorf("ReplicaSet does not support this operation")
+}

--- a/pkg/workload/replicaset_test.go
+++ b/pkg/workload/replicaset_test.go
@@ -25,17 +25,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestDeployment_Sort(t *testing.T) {
+func TestReplicaSet_Sort(t *testing.T) {
 	// TODO
 }
 
-func TestDeployment_CanSelectPodsToScaleDown(t *testing.T) {
-	deployment := Deployment{}
-	result := deployment.CanSelectPodsToScaleDown(context.Background())
-	assert.False(t, result, "can't select pods to scale down for deployment resource")
+func TestReplicaSet_CanSelectPodsToScaleDown(t *testing.T) {
+	ReplicaSet := ReplicaSet{}
+	result := ReplicaSet.CanSelectPodsToScaleDown(context.Background())
+	assert.False(t, result, "can't select pods to scale down for replicaset resource")
 }
 
-func TestDeployment_SelectPodsToScaleDown(t *testing.T) {
+func TestReplicaSet_SelectPodsToScaleDown(t *testing.T) {
 	pods := []*corev1.Pod{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -49,7 +49,7 @@ func TestDeployment_SelectPodsToScaleDown(t *testing.T) {
 		},
 	}
 
-	deployment := Deployment{}
-	err := deployment.SelectPodsToScaleDown(context.Background(), pods)
-	assert.NotNil(t, err, "does not support select pods for deployment resource")
+	ReplicaSet := ReplicaSet{}
+	err := ReplicaSet.SelectPodsToScaleDown(context.Background(), pods)
+	assert.NotNil(t, err, "does not support select pods for replicaset resource")
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR introduces support for Deployment and ReplicaSet pod sorting with the default `ActivePodsWithRanks` sorter.

#### Which issue(s) this PR fixes:
Fixes #7
