### PR TITLE
HorizontalPortrait: fix float64 field parse issue

### DIFF
--- a/apis/autoscaling/v1alpha1/horizontalportrait_types.go
+++ b/apis/autoscaling/v1alpha1/horizontalportrait_types.go
@@ -17,8 +17,6 @@
 package v1alpha1
 
 import (
-	"encoding/json"
-
 	k8sautoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -142,7 +140,7 @@ type KubeHPAPortraitAlgorithm struct {
 	// Should be a string formatted float64 number.
 	// +optional
 	// +kubebuilder:default="0.1"
-	Tolerance json.Number `json:"tolerance"`
+	Tolerance string `json:"tolerance"`
 
 	// CPUInitializationPeriod is the period after pod start when CPU samples might be skipped.
 	// +optional

--- a/pkg/portrait/generator/reactive/generator.go
+++ b/pkg/portrait/generator/reactive/generator.go
@@ -19,6 +19,7 @@ package reactive
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	k8sautoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -72,7 +73,7 @@ func (g *PortraitGenerator) GenerateHorizontal(ctx context.Context, namespace st
 	cfg := algorithm.KubeHPA
 	if cfg != nil {
 		syncPeriod = cfg.SyncPeriod.Duration
-		tolerance, err = cfg.Tolerance.Float64()
+		tolerance, err = strconv.ParseFloat(cfg.Tolerance, 64)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to parse tolerance of KubeHPA algorithm to float64: %v", err)
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind api-change

#### What this PR does / why we need it:
This PR changes the type of `Tolerance` field of `KubeHPAPortraitAlgorithm` from `json.Number` to raw `string`. This fixes the issue that IHPA cannot successfully propagate the field to HorizontalPortrait due to internal json parse issue.