### PR TITLE
Make util.BuildControllerOwnerRef behave the same as metav1.NewControllerRef

### DIFF
--- a/controllers/autoscaling/intelligenthorizontalpodautoscaler_controller.go
+++ b/controllers/autoscaling/intelligenthorizontalpodautoscaler_controller.go
@@ -313,7 +313,7 @@ func newReplicaProfile(ihpa *autoscalingv1alpha1.IntelligentHorizontalPodAutosca
 			Namespace: ihpa.Namespace,
 			Name:      ihpa.Name,
 			OwnerReferences: []metav1.OwnerReference{
-				util.BuildControllerOwnerRef(ihpa),
+				*util.NewControllerRef(ihpa),
 			},
 		},
 		Spec: autoscalingv1alpha1.ReplicaProfileSpec{

--- a/pkg/portrait/provider/dynamic.go
+++ b/pkg/portrait/provider/dynamic.go
@@ -72,7 +72,7 @@ func (h *DynamicHorizontal) UpdatePortraitSpec(ctx context.Context, ihpa *autosc
 					Namespace: hpNamespacedName.Namespace,
 					Name:      hpNamespacedName.Name,
 					OwnerReferences: []metav1.OwnerReference{
-						util.BuildControllerOwnerRef(ihpa),
+						*util.NewControllerRef(ihpa),
 					},
 				},
 				Spec: hpSpec,

--- a/pkg/util/apimachinery.go
+++ b/pkg/util/apimachinery.go
@@ -85,14 +85,15 @@ func ParseGVK(apiVersion, kind string) (schema.GroupVersionKind, error) {
 	return gv.WithKind(kind), nil
 }
 
-// BuildControllerOwnerRef builds a controller owner reference to the given Kubernetes object.
-func BuildControllerOwnerRef(obj client.Object) metav1.OwnerReference {
-	return metav1.OwnerReference{
-		APIVersion: obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
-		Kind:       obj.GetObjectKind().GroupVersionKind().Kind,
-		Name:       obj.GetName(),
-		UID:        obj.GetUID(),
-		Controller: pointer.Bool(true),
+// NewControllerRef creates a controller owner reference pointing to the given owner.
+func NewControllerRef(obj client.Object) *metav1.OwnerReference {
+	return &metav1.OwnerReference{
+		APIVersion:         obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		Kind:               obj.GetObjectKind().GroupVersionKind().Kind,
+		Name:               obj.GetName(),
+		UID:                obj.GetUID(),
+		Controller:         pointer.Bool(true),
+		BlockOwnerDeletion: pointer.Bool(true),
 	}
 }
 

--- a/pkg/util/apimachinery_test.go
+++ b/pkg/util/apimachinery_test.go
@@ -83,12 +83,14 @@ func TestParseGVK(t *testing.T) {
 	assert.Equal(t, horizontalPortrait.GroupVersionKind(), groupVersion)
 }
 
-func TestBuildControllerOwnerRef(t *testing.T) {
-	ownerRef := BuildControllerOwnerRef(horizontalPortrait)
-	assert.Equal(t, horizontalPortrait.GroupVersionKind().Kind, ownerRef.Kind)
+func TestNewControllerRef(t *testing.T) {
+	ownerRef := NewControllerRef(horizontalPortrait)
 	assert.Equal(t, horizontalPortrait.APIVersion, ownerRef.APIVersion)
-	assert.Equal(t, horizontalPortrait.ObjectMeta.Name, ownerRef.Name)
-	assert.Equal(t, horizontalPortrait.ObjectMeta.UID, ownerRef.UID)
+	assert.Equal(t, horizontalPortrait.Kind, ownerRef.Kind)
+	assert.Equal(t, horizontalPortrait.Name, ownerRef.Name)
+	assert.Equal(t, horizontalPortrait.UID, ownerRef.UID)
+	assert.Equal(t, true, *ownerRef.Controller)
+	assert.Equal(t, true, *ownerRef.BlockOwnerDeletion)
 }
 
 func TestParseScaleSelector(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR makes the original `util.BuildControllerOwnerRef` behave the same as `metav1.NewControllerRef`, which includes below changes:
* controller owner ref would block owner deletion
* the new function would return a pointer